### PR TITLE
Allow updating multiple requirements

### DIFF
--- a/backend/src/courses/courses.controller.ts
+++ b/backend/src/courses/courses.controller.ts
@@ -1,23 +1,8 @@
-import {
-  Controller,
-  Get,
-  Post,
-  Body,
-  Param,
-  Put,
-  Delete,
-  UseGuards,
-  ParseIntPipe,
-  NotFoundException,
-  ValidationPipe,
-} from '@nestjs/common'
-import { JwtAuthGuard } from '../auth/jwt-auth.guard'
+import { Controller, Get, Post, Body, Param, Put, Delete, UseGuards } from '@nestjs/common'
 import { CoursesService } from './courses.service'
 import { Course } from './entities/course.entity'
-import { CreateCourseDto, UpdateCourseDto } from './dto/'
-import { Rule } from '../rules/entities/rule.entity'
-import { CreateRuleDto, UpdateRuleDto } from '../rules/dto/rule.dto'
-import { RuleType } from '../rules/entities/rule.enum'
+import { JwtAuthGuard } from '../auth/jwt-auth.guard'
+import { CreateCourseDto, UpdateCourseDto } from './dto'
 
 @Controller('courses')
 @UseGuards(JwtAuthGuard)
@@ -25,128 +10,35 @@ export class CoursesController {
   constructor(private readonly coursesService: CoursesService) {}
 
   @Get()
-  async findAll(): Promise<Course[]> {
+  findAll(): Promise<any[]> {
     return this.coursesService.findAll()
   }
 
   @Get(':id')
-  async findOne(@Param('id', ParseIntPipe) id: number): Promise<Course> {
-    const course = await this.coursesService.findOne(id)
-    if (!course) {
-      throw new NotFoundException(`Course with ID "${id}" not found`)
-    }
-    return course
+  findOne(@Param('id') id: string): Promise<any> {
+    return this.coursesService.findOne(+id)
   }
 
-  @Get('code/:code/version/:version')
+  @Get('/:code/:version')
   findByCodeAndVersion(
     @Param('code') code: string,
     @Param('version') version: string
   ): Promise<Course> {
     return this.coursesService.findByCodeAndVersion(code, version)
   }
+
   @Post()
-  async create(@Body(ValidationPipe) createCourseDto: CreateCourseDto): Promise<Course> {
+  create(@Body() createCourseDto: CreateCourseDto): Promise<Course> {
     return this.coursesService.create(createCourseDto)
   }
 
   @Put(':id')
-  async update(
-    @Param('id', ParseIntPipe) id: number,
-    @Body(ValidationPipe) updateCourseDto: UpdateCourseDto
-  ): Promise<Course> {
-    const updatedCourse = await this.coursesService.update(id, updateCourseDto)
-    if (!updatedCourse) {
-      throw new NotFoundException(`Course with ID "${id}" not found`)
-    }
-    return updatedCourse
+  update(@Param('id') id: string, @Body() updateCourseDto: UpdateCourseDto): Promise<Course> {
+    return this.coursesService.update(+id, updateCourseDto)
   }
 
   @Delete(':id')
-  async remove(@Param('id', ParseIntPipe) id: number): Promise<void> {
-    await this.coursesService.remove(id)
-  }
-
-  // Rule-related endpoints
-
-  @Get(':id/rules')
-  async findAllRules(@Param('id', ParseIntPipe) id: number): Promise<Rule[]> {
-    console.log('Fetching all rules')
-
-    return this.coursesService.findAllRules(id)
-  }
-
-  @Get(':id/rules/:ruleId')
-  async findOneRule(
-    @Param('id', ParseIntPipe) id: number,
-    @Param('ruleId', ParseIntPipe) ruleId: number
-  ): Promise<Rule> {
-    const rule = await this.coursesService.findOneRule(id, ruleId)
-    if (!rule) {
-      throw new NotFoundException(`Rule with ID "${ruleId}" not found in course "${id}"`)
-    }
-    return rule
-  }
-
-  @Get(':id/rules/by-type/:type')
-  async findRuleByType(
-    @Param('id', ParseIntPipe) id: number,
-    @Param('type') type: RuleType
-  ): Promise<Rule> {
-    const rule = await this.coursesService.findRuleByType(id, type)
-    if (!rule) {
-      throw new NotFoundException(`Rule with type "${type}" not found in course "${id}"`)
-    }
-    return rule
-  }
-
-  @Post(':id/rules')
-  async createRule(
-    @Param('id', ParseIntPipe) id: number,
-    @Body(ValidationPipe) createRuleDto: CreateRuleDto
-  ): Promise<Rule> {
-    return this.coursesService.createRule(id, createRuleDto)
-  }
-
-  @Put(':id/rules/:ruleId')
-  async updateRule(
-    @Param('id', ParseIntPipe) id: number,
-    @Param('ruleId', ParseIntPipe) ruleId: number,
-    @Body(ValidationPipe) updateRuleDto: UpdateRuleDto
-  ): Promise<Rule> {
-    const updatedRule = await this.coursesService.updateRule(id, ruleId, updateRuleDto)
-    if (!updatedRule) {
-      throw new NotFoundException(`Rule with ID "${ruleId}" not found in course "${id}"`)
-    }
-    return updatedRule
-  }
-
-  @Put(':id/rules/by-type/:type')
-  async updateRuleByType(
-    @Param('id', ParseIntPipe) id: number,
-    @Param('type') type: RuleType,
-    @Body(ValidationPipe) updateRuleDto: UpdateRuleDto
-  ): Promise<Rule> {
-    const updatedRule = await this.coursesService.updateRuleByType(id, type, updateRuleDto)
-    if (!updatedRule) {
-      throw new NotFoundException(`Rule with type "${type}" not found in course "${id}"`)
-    }
-    return updatedRule
-  }
-
-  @Delete(':id/rules/:ruleId')
-  async removeRule(
-    @Param('id', ParseIntPipe) id: number,
-    @Param('ruleId', ParseIntPipe) ruleId: number
-  ): Promise<void> {
-    await this.coursesService.removeRule(id, ruleId)
-  }
-
-  @Delete(':id/rules/by-type/:type')
-  async removeRuleByType(
-    @Param('id', ParseIntPipe) id: number,
-    @Param('type') type: RuleType
-  ): Promise<void> {
-    await this.coursesService.removeRuleByType(id, type)
+  remove(@Param('id') id: string): Promise<void> {
+    return this.coursesService.remove(+id)
   }
 }

--- a/backend/src/courses/courses.module.ts
+++ b/backend/src/courses/courses.module.ts
@@ -1,15 +1,11 @@
-import { Module, forwardRef } from '@nestjs/common'
+import { Module } from '@nestjs/common'
 import { TypeOrmModule } from '@nestjs/typeorm'
 import { Course } from './entities/course.entity'
 import { CoursesService } from './courses.service'
 import { CoursesController } from './courses.controller'
-import { RulesModule } from '../rules/rules.module'
 
 @Module({
-  imports: [
-    TypeOrmModule.forFeature([Course]),
-    forwardRef(() => RulesModule), // 使用 forwardRef 来处理循环依赖
-  ],
+  imports: [TypeOrmModule.forFeature([Course])],
   providers: [CoursesService],
   controllers: [CoursesController],
   exports: [TypeOrmModule, CoursesService],

--- a/backend/src/courses/courses.service.ts
+++ b/backend/src/courses/courses.service.ts
@@ -1,50 +1,33 @@
 import { Injectable, NotFoundException } from '@nestjs/common'
 import { InjectRepository } from '@nestjs/typeorm'
-import { DeepPartial, Repository } from 'typeorm'
+import { Repository } from 'typeorm'
 import { Course } from './entities/course.entity'
 import { CreateCourseDto, UpdateCourseDto } from './dto'
-import { RuleType } from '../rules/entities/rule.enum'
-import { Rule } from '../rules/entities/rule.entity'
-import { CreateRuleDto, UpdateRuleDto } from '../rules/dto/rule.dto'
-import { NumberingStyle } from '../requirements/entities/style.enum'
 
 @Injectable()
 export class CoursesService {
   constructor(
     @InjectRepository(Course)
-    private coursesRepository: Repository<Course>,
-    @InjectRepository(Rule)
-    private rulesRepository: Repository<Rule>
+    private coursesRepository: Repository<Course>
   ) {}
 
+  // 获取所有课程，并动态生成 versions 字段
   async findAll(): Promise<any[]> {
-    // 获取所有课程
-    const allCourses = await this.coursesRepository.find({
-      order: { code: 'ASC', version: 'DESC' },
-    })
+    const courses = await this.coursesRepository.find()
 
-    // 使用 Map 来存储每个课程代码的最新版本
-    const latestVersions = new Map<string, Course>()
-
-    allCourses.forEach((course) => {
-      if (!latestVersions.has(course.code)) {
-        latestVersions.set(course.code, course)
-      }
-    })
-
-    // 为每个最新版本的课程添加 versions 字段
+    // 动态生成每个课程的 versions 字段
     return await Promise.all(
-      Array.from(latestVersions.values()).map(async (course) => {
-        const versions = await this.coursesRepository
-          .createQueryBuilder('course')
-          .select('course.version', 'version')
-          .where('course.code = :code', { code: course.code })
-          .orderBy('course.version', 'DESC')
-          .getRawMany()
+      courses.map(async (course) => {
+        const relatedCourses = await this.coursesRepository.find({
+          where: { code: course.code },
+          order: { version: 'DESC' },
+        })
+
+        const versions = relatedCourses.map((c) => c.version.toString())
 
         return {
           ...course,
-          versions: versions.map((v) => v.version.toString()),
+          versions, // 动态生成的 versions 数组
         }
       })
     )
@@ -95,79 +78,14 @@ export class CoursesService {
 
   async findByCodeAndVersion(code: string, version: string): Promise<Course> {
     const course = await this.coursesRepository.findOne({
-      where: { code, version: version.toString() },
+      where: { code, version: +version },
     })
 
     if (!course) {
       throw new NotFoundException(`Course with code "${code}" and version "${version}" not found`)
     }
 
+    // 只返回匹配的课程信息，不附带 versions
     return course
-  }
-
-  async findAllRules(courseId: number): Promise<Rule[]> {
-    const course = await this.findOne(courseId)
-    return this.rulesRepository.find({ where: { course: { id: course.id } } })
-  }
-
-  async findOneRule(courseId: number, ruleId: number): Promise<Rule> {
-    const course = await this.findOne(courseId)
-    return this.rulesRepository.findOne({ where: { id: ruleId, course: { id: course.id } } })
-  }
-
-  async findRuleByType(courseId: number, type: RuleType): Promise<Rule> {
-    const course = await this.findOne(courseId)
-    return this.rulesRepository.findOne({ where: { type, course: { id: course.id } } })
-  }
-
-  async createRule(courseId: number, createRuleDto: CreateRuleDto): Promise<Rule> {
-    const course = await this.findOne(courseId)
-    const rule = this.rulesRepository.create({
-      ...createRuleDto,
-      course,
-      requirements: createRuleDto.requirements?.map((req) => ({
-        ...req,
-        style: req.style as NumberingStyle,
-      })),
-    } as DeepPartial<Rule>)
-    return this.rulesRepository.save(rule as Rule)
-  }
-
-  async updateRule(courseId: number, ruleId: number, updateRuleDto: UpdateRuleDto): Promise<Rule> {
-    const rule = await this.findOneRule(courseId, ruleId)
-    if (!rule) {
-      throw new NotFoundException(`Rule with ID "${ruleId}" not found in course "${courseId}"`)
-    }
-    Object.assign(rule, updateRuleDto)
-    return this.rulesRepository.save(rule)
-  }
-
-  async updateRuleByType(
-    courseId: number,
-    type: RuleType,
-    updateRuleDto: UpdateRuleDto
-  ): Promise<Rule> {
-    const rule = await this.findRuleByType(courseId, type)
-    if (!rule) {
-      throw new NotFoundException(`Rule with type "${type}" not found in course "${courseId}"`)
-    }
-    Object.assign(rule, updateRuleDto)
-    return this.rulesRepository.save(rule)
-  }
-
-  async removeRule(courseId: number, ruleId: number): Promise<void> {
-    const rule = await this.findOneRule(courseId, ruleId)
-    if (!rule) {
-      throw new NotFoundException(`Rule with ID "${ruleId}" not found in course "${courseId}"`)
-    }
-    await this.rulesRepository.remove(rule)
-  }
-
-  async removeRuleByType(courseId: number, type: RuleType): Promise<void> {
-    const rule = await this.findRuleByType(courseId, type)
-    if (!rule) {
-      throw new NotFoundException(`Rule with type "${type}" not found in course "${courseId}"`)
-    }
-    await this.rulesRepository.remove(rule)
   }
 }

--- a/backend/src/courses/dto/create-course.dto.ts
+++ b/backend/src/courses/dto/create-course.dto.ts
@@ -1,0 +1,1 @@
+export class CreateCourseDto {}

--- a/backend/src/courses/dto/index.ts
+++ b/backend/src/courses/dto/index.ts
@@ -1,41 +1,15 @@
-import { IsString, IsBoolean, IsOptional } from 'class-validator'
-
 export class CreateCourseDto {
-  @IsString()
   code: string
-
-  @IsString()
   name: string
-
-  @IsString()
-  @IsOptional()
-  description?: string
-
-  @IsString()
-  version: string
-
-  @IsBoolean()
+  description: string
+  version: number
   is_current: boolean
 }
 
 export class UpdateCourseDto {
-  @IsString()
-  @IsOptional()
   code?: string
-
-  @IsString()
-  @IsOptional()
   name?: string
-
-  @IsString()
-  @IsOptional()
   description?: string
-
-  @IsString()
-  @IsOptional()
-  version?: string
-
-  @IsBoolean()
-  @IsOptional()
+  version?: number
   is_current?: boolean
 }

--- a/backend/src/courses/dto/update-course.dto.ts
+++ b/backend/src/courses/dto/update-course.dto.ts
@@ -1,0 +1,4 @@
+import { PartialType } from '@nestjs/mapped-types'
+import { CreateCourseDto } from './create-course.dto'
+
+export class UpdateCourseDto extends PartialType(CreateCourseDto) {}

--- a/backend/src/courses/entities/course.entity.ts
+++ b/backend/src/courses/entities/course.entity.ts
@@ -30,7 +30,7 @@ export class Course {
   type: CourseType
 
   @Column()
-  version: string
+  version: number
 
   @Column()
   is_current: boolean

--- a/backend/src/requirements/requirements.controller.ts
+++ b/backend/src/requirements/requirements.controller.ts
@@ -9,7 +9,6 @@ import {
   UseGuards,
   ParseIntPipe,
   Logger,
-  ValidationPipe
 } from '@nestjs/common'
 import { RequirementsService } from './requirements.service'
 import { Requirement } from './entities/requirement.entity'
@@ -21,13 +20,13 @@ import { CreateRequirementDto, UpdateRequirementDto } from './dto/requirement.dt
 export class RequirementsController {
   private readonly logger = new Logger(RequirementsController.name)
 
-  constructor(private readonly requirementsService: RequirementsService) { }
+  constructor(private readonly requirementsService: RequirementsService) {}
 
   @Get()
   async findAllRequirements(
     @Param('courseId', ParseIntPipe) courseId: number,
     @Param('ruleId', ParseIntPipe) ruleId: number
-  ): Promise<Omit<Requirement, 'parentId'>[]> {
+  ): Promise<Requirement[]> {
     this.logger.log(`Fetching all requirements for rule ${ruleId} in course ${courseId}`)
     return this.requirementsService.findAllRequirements(courseId, ruleId)
   }
@@ -36,7 +35,7 @@ export class RequirementsController {
   async createRequirement(
     @Param('courseId', ParseIntPipe) courseId: number,
     @Param('ruleId', ParseIntPipe) ruleId: number,
-    @Body(new ValidationPipe({ whitelist: true })) createRequirementDtos: CreateRequirementDto[]
+    @Body() createRequirementDtos: CreateRequirementDto[]
   ): Promise<Requirement[]> {
     this.logger.log(`Receive createRequirement request：${JSON.stringify(createRequirementDtos)}`)
     return Promise.all(
@@ -46,18 +45,22 @@ export class RequirementsController {
     )
   }
 
-  @Put()
-  async updateRequirements(
+  @Put(':requirementId')
+  async updateRequirement(
     @Param('courseId', ParseIntPipe) courseId: number,
     @Param('ruleId', ParseIntPipe) ruleId: number,
-    @Body() updateRequirementData: UpdateRequirementDto | UpdateRequirementDto[]
-  ): Promise<Requirement[]> {
-    this.logger.log(`Updating requirements for rule ${ruleId} in course ${courseId}`)
-    // Ensure we're always passing an array to the service
-    const updateRequirementDtos = Array.isArray(updateRequirementData)
-      ? updateRequirementData
-      : [updateRequirementData]
-    return this.requirementsService.updateRequirements(courseId, ruleId, updateRequirementDtos)
+    @Param('requirementId', ParseIntPipe) requirementId: number,
+    @Body() updateRequirementDto: UpdateRequirementDto
+  ): Promise<Requirement> {
+    this.logger.log(
+      `Updating requirement ${requirementId} for rule ${ruleId} in course ${courseId}`
+    )
+    return this.requirementsService.updateRequirement(
+      courseId,
+      ruleId,
+      requirementId,
+      updateRequirementDto
+    )
   }
 
   @Delete(':requirementId')

--- a/backend/src/requirements/requirements.service.ts
+++ b/backend/src/requirements/requirements.service.ts
@@ -1,17 +1,9 @@
-import {
-  Injectable,
-  NotFoundException,
-  Logger,
-  InternalServerErrorException,
-  BadRequestException,
-} from '@nestjs/common'
+import { Injectable, NotFoundException, Logger, InternalServerErrorException } from '@nestjs/common'
 import { InjectRepository } from '@nestjs/typeorm'
-import { Repository, DataSource, QueryRunner, In } from 'typeorm'
+import { Repository, DataSource } from 'typeorm'
 import { Requirement } from './entities/requirement.entity'
 import { Rule } from '../rules/entities/rule.entity'
 import { CreateRequirementDto, UpdateRequirementDto } from './dto/requirement.dto'
-import { NumberingStyle } from './entities/style.enum'
-import { DeepPartial } from 'typeorm'
 
 @Injectable()
 export class RequirementsService {
@@ -23,66 +15,16 @@ export class RequirementsService {
     @InjectRepository(Rule)
     private rulesRepository: Repository<Rule>,
     private dataSource: DataSource
-  ) { }
+  ) {}
 
-  async findAllRequirements(
-    courseId: number,
-    ruleId: number
-  ): Promise<Omit<Requirement, 'parentId'>[]> {
-    const rule = await this.rulesRepository.findOne({
-      where: { id: ruleId, course: { id: courseId } },
-    })
-
-    if (!rule) {
-      throw new NotFoundException(`Rule with ID ${ruleId} not found in course ${courseId}`)
-    }
-
-    const allRequirements = await this.requirementsRepository.find({
-      where: { rule: { id: ruleId } },
+  async findAllRequirements(courseId: number, ruleId: number): Promise<Requirement[]> {
+    this.logger.log(`Fetching all requirements for rule ${ruleId} in course ${courseId}`)
+    return this.requirementsRepository.find({
+      where: { rule: { id: ruleId, course: { id: courseId } } },
       order: { order_index: 'ASC' },
     })
-
-    // Build a tree structure
-    const requirementMap = new Map<
-      number,
-      Omit<Requirement, 'parentId'> & { children: Omit<Requirement, 'parentId'>[] }
-    >()
-    const rootRequirements: (Omit<Requirement, 'parentId'> & {
-      children: Omit<Requirement, 'parentId'>[]
-    })[] = []
-
-    allRequirements.forEach((req) => {
-      const { parentId, ...reqWithoutParentId } = req
-      requirementMap.set(req.id, {
-        ...reqWithoutParentId,
-        isConnector: Boolean(reqWithoutParentId.isConnector),
-        children: [],
-      })
-    })
-
-    allRequirements.forEach((req) => {
-      const requirement = requirementMap.get(req.id)
-      if (req.parentId) {
-        const parentReq = requirementMap.get(req.parentId)
-        if (parentReq) {
-          parentReq.children.push(requirement)
-        }
-      } else {
-        rootRequirements.push(requirement)
-      }
-    })
-
-    return rootRequirements
   }
 
-  private async loadChildrenRecursively(requirements: Requirement[]): Promise<Requirement[]> {
-    for (const requirement of requirements) {
-      if (requirement.children && requirement.children.length > 0) {
-        requirement.children = await this.loadChildrenRecursively(requirement.children)
-      }
-    }
-    return requirements.sort((a, b) => a.id - b.id)
-  }
   async createRequirement(
     courseId: number,
     ruleId: number,
@@ -100,19 +42,20 @@ export class RequirementsService {
         throw new NotFoundException(`Rule with ID "${ruleId}" not found in course "${courseId}"`)
       }
 
-      const { children, ...requirementData } = createRequirementDto
       const requirement = this.requirementsRepository.create({
-        ...requirementData,
-        style: requirementData.style as NumberingStyle,
+        content: createRequirementDto.content,
+        style: createRequirementDto.style,
+        isConnector: createRequirementDto.is_connector,
+        order_index: createRequirementDto.order_index,
         rule,
-      } as DeepPartial<Requirement>)
+      })
 
       this.logger.log(`Creating requirement: ${JSON.stringify(requirement)}`)
       const savedRequirement = await queryRunner.manager.save(requirement)
       this.logger.log(`Saved requirement: ${JSON.stringify(savedRequirement)}`)
 
-      if (children && children.length > 0) {
-        await this.createChildren(savedRequirement, children, queryRunner)
+      if (createRequirementDto.children && createRequirementDto.children.length > 0) {
+        await this.createChildren(savedRequirement, createRequirementDto.children, queryRunner)
       }
 
       await queryRunner.commitTransaction()
@@ -134,165 +77,46 @@ export class RequirementsService {
   private async createChildren(
     parentRequirement: Requirement,
     children: CreateRequirementDto[],
-    queryRunner: QueryRunner
+    queryRunner: any
   ): Promise<void> {
     for (const childDto of children) {
-      const { children: grandchildren, ...childData } = childDto
       const childRequirement = this.requirementsRepository.create({
-        ...childData,
-        style: childData.style as NumberingStyle,
-        parentId: parentRequirement.id,
+        content: childDto.content,
+        style: childDto.style,
+        isConnector: childDto.is_connector,
+        order_index: childDto.order_index,
+        parent: parentRequirement,
         rule: parentRequirement.rule,
-      } as DeepPartial<Requirement>)
+      })
 
       this.logger.log(`Creating child requirement: ${JSON.stringify(childRequirement)}`)
       const savedChild = await queryRunner.manager.save(childRequirement)
       this.logger.log(`Saved child requirement: ${JSON.stringify(savedChild)}`)
 
-      if (grandchildren && grandchildren.length > 0) {
-        await this.createChildren(savedChild, grandchildren, queryRunner)
+      if (childDto.children && childDto.children.length > 0) {
+        await this.createChildren(savedChild, childDto.children, queryRunner)
       }
     }
   }
 
-  async updateRequirements(
+  async updateRequirement(
     courseId: number,
     ruleId: number,
-    updateRequirementDtos: UpdateRequirementDto | UpdateRequirementDto[]
-  ): Promise<Requirement[]> {
-    const queryRunner = this.dataSource.createQueryRunner()
-    await queryRunner.connect()
-    await queryRunner.startTransaction()
+    requirementId: number,
+    updateRequirementDto: UpdateRequirementDto
+  ): Promise<Requirement> {
+    const requirement = await this.requirementsRepository.findOne({
+      where: { id: requirementId, rule: { id: ruleId, course: { id: courseId } } },
+    })
 
-    try {
-      const rule = await this.rulesRepository.findOne({
-        where: { id: ruleId, course: { id: courseId } },
-      })
-      if (!rule) {
-        throw new NotFoundException(`Rule with ID "${ruleId}" not found in course "${courseId}"`)
-      }
-
-      // Ensure updateRequirementDtos is an array
-      const dtos = Array.isArray(updateRequirementDtos)
-        ? updateRequirementDtos
-        : [updateRequirementDtos]
-
-      // Fetch all existing requirements for this rule
-      const existingRequirements = await this.requirementsRepository.find({
-        where: { rule: { id: ruleId } },
-        relations: ['children'],
-      })
-
-      // Update or create requirements
-      const updatedRequirements = await this.updateOrCreateRequirements(
-        rule,
-        dtos,
-        existingRequirements,
-        null,
-        queryRunner
+    if (!requirement) {
+      throw new NotFoundException(
+        `Requirement with ID "${requirementId}" not found in rule "${ruleId}" and course "${courseId}"`
       )
-
-      // Delete requirements that are no longer needed
-      await this.deleteUnusedRequirements(existingRequirements, dtos, queryRunner)
-
-      await queryRunner.commitTransaction()
-      this.logger.log(`Updated requirements for rule ${ruleId}`)
-
-      return updatedRequirements
-    } catch (err) {
-      this.logger.error(`Failed to update requirements for rule ${ruleId}`, err.stack)
-      await queryRunner.rollbackTransaction()
-      if (err instanceof BadRequestException) {
-        throw err
-      }
-      throw new InternalServerErrorException('Failed to update requirements')
-    } finally {
-      await queryRunner.release()
-    }
-  }
-
-  private async updateOrCreateRequirements(
-    rule: Rule,
-    requirementDtos: UpdateRequirementDto[],
-    existingRequirements: Requirement[],
-    parent: Requirement | null,
-    queryRunner: QueryRunner
-  ): Promise<Requirement[]> {
-    if (!Array.isArray(requirementDtos)) {
-      throw new BadRequestException('Invalid input: requirementDtos must be an array')
     }
 
-    const updatedRequirements: Requirement[] = []
-
-    for (const dto of requirementDtos) {
-      let requirement = dto.id ? existingRequirements.find((r) => r.id === dto.id) : null
-
-      if (requirement) {
-        // Update existing requirement
-        requirement.content = dto.content ?? requirement.content
-        requirement.style = (dto.style as NumberingStyle) ?? requirement.style
-        requirement.isConnector = dto.isConnector ?? requirement.isConnector
-        requirement.order_index = dto.order_index ?? requirement.order_index
-      } else {
-        // Create new requirement
-        const { id, children, ...requirementData } = dto
-        requirement = this.requirementsRepository.create({
-          ...requirementData,
-          style: requirementData.style as NumberingStyle,
-          rule,
-          parent,
-        } as DeepPartial<Requirement>)
-      }
-
-      this.logger.log(
-        `Before saving, isConnector: ${requirement.isConnector}, dto.isConnector: ${dto.isConnector}`
-      )
-      const savedRequirement = await queryRunner.manager.save(requirement)
-      this.logger.log(`After saving, isConnector: ${savedRequirement.isConnector}`)
-
-      if (dto.children && dto.children.length > 0) {
-        const children = await this.updateOrCreateRequirements(
-          rule,
-          dto.children,
-          requirement.children || [],
-          savedRequirement,
-          queryRunner
-        )
-        savedRequirement.children = children
-      }
-
-      updatedRequirements.push(savedRequirement)
-    }
-
-    return updatedRequirements
-  }
-  private async deleteUnusedRequirements(
-    existingRequirements: Requirement[],
-    updateRequirementDtos: UpdateRequirementDto[],
-    queryRunner: QueryRunner
-  ): Promise<void> {
-    const updatedIds = new Set(
-      updateRequirementDtos.map((dto) => dto.id).filter((id) => id !== undefined)
-    )
-    const requirementsToDelete = existingRequirements.filter((req) => !updatedIds.has(req.id))
-
-    if (requirementsToDelete.length > 0) {
-      const idsToDelete = requirementsToDelete.map((req) => req.id)
-      await queryRunner.manager.delete(Requirement, { id: In(idsToDelete) })
-      this.logger.log(`Deleted requirements with IDs: ${idsToDelete.join(', ')}`)
-    }
-  }
-
-  private async deleteRequirementRecursively(
-    requirement: Requirement,
-    queryRunner: QueryRunner
-  ): Promise<void> {
-    if (requirement.children && requirement.children.length > 0) {
-      for (const child of requirement.children) {
-        await this.deleteRequirementRecursively(child, queryRunner)
-      }
-    }
-    await queryRunner.manager.remove(Requirement, requirement)
+    Object.assign(requirement, updateRequirementDto)
+    return this.requirementsRepository.save(requirement)
   }
 
   async removeRequirement(courseId: number, ruleId: number, requirementId: number): Promise<void> {
@@ -323,10 +147,9 @@ export class RequirementsService {
 
     const childRequirement = this.requirementsRepository.create({
       ...createRequirementDto,
-      style: createRequirementDto.style as NumberingStyle,
       parent: parentRequirement,
       rule: parentRequirement.rule,
-    } as DeepPartial<Requirement>)
+    })
 
     return this.requirementsRepository.save(childRequirement)
   }

--- a/backend/src/rules/rules.controller.ts
+++ b/backend/src/rules/rules.controller.ts
@@ -10,87 +10,67 @@ import {
   ParseIntPipe,
   Logger,
   NotFoundException,
-  Query,
 } from '@nestjs/common'
 import { RulesService } from './rules.service'
 import { Rule } from './entities/rule.entity'
 import { JwtAuthGuard } from '../auth/jwt-auth.guard'
-import { CreateRuleDto, UpdateRuleDto, RuleWithHierarchyDto, RequirementHierarchyDto } from './dto/rule.dto'
-import { RuleType } from './entities/rule.enum'
-import { Requirement } from '../requirements/entities/requirement.entity'
+import { CreateRuleDto, UpdateRuleDto } from './dto/rule.dto'
 
 @Controller('courses/:courseId/rules')
 @UseGuards(JwtAuthGuard)
 export class RulesController {
   private readonly logger = new Logger(RulesController.name)
 
-  constructor(private readonly rulesService: RulesService) { }
+  constructor(private readonly rulesService: RulesService) {}
 
   @Get()
-  async findAllRules(@Param('courseId', ParseIntPipe) courseId: number): Promise<RuleWithHierarchyDto[]> {
-    const rules = await this.rulesService.findAllRules(courseId)
-    const rulesWithHierarchy: RuleWithHierarchyDto[] = []
-
-    for (const rule of rules) {
-      const requirements = await this.rulesService.findRuleRequirementsHierarchy(rule.id)
-      rulesWithHierarchy.push({
-        ...rule,
-        requirements: this.mapRequirementsToDto(requirements.filter(req => !req.parentId)),
-      })
-    }
-
-    return rulesWithHierarchy
-  }
-
-  private mapRequirementsToDto(requirements: Requirement[]): RequirementHierarchyDto[] {
-    return requirements.map(req => ({
-      id: req.id,
-      content: req.content,
-      style: req.style,
-      is_connector: req.isConnector,  // Map isConnector to is_connector
-      order_index: req.order_index,
-      children: req.children ? this.mapRequirementsToDto(req.children) : [],
-    }))
+  async findAll(@Param('courseId', ParseIntPipe) courseId: number): Promise<Rule[]> {
+    this.logger.log(`Fetching all rules for course ${courseId}`)
+    return this.rulesService.findAll(courseId)
   }
 
   @Get(':id')
-  async findOne(@Param('id', ParseIntPipe) id: number): Promise<Rule> {
-    this.logger.log(`Fetching rule ${id}`)
-    const rule = await this.rulesService.findOne(id)
+  async findOne(
+    @Param('courseId', ParseIntPipe) courseId: number,
+    @Param('id', ParseIntPipe) id: number
+  ): Promise<Rule> {
+    this.logger.log(`Fetching rule ${id} for course ${courseId}`)
+    const rule = await this.rulesService.findOne(courseId, id)
     if (!rule) {
-      throw new NotFoundException(`Rule with ID "${id}" not found`)
+      throw new NotFoundException(`Rule with ID "${id}" not found in course "${courseId}"`)
     }
     return rule
   }
 
-  @Get('by-type/:type')
-  async findByType(@Param('type') type: RuleType): Promise<Rule[]> {
-    this.logger.log(`Fetching rules with type ${type}`)
-    return this.rulesService.findByType(type)
-  }
-
   @Post()
-  async create(@Body() createRuleDto: CreateRuleDto): Promise<Rule> {
-    this.logger.log('Creating new rule')
-    return this.rulesService.create(createRuleDto)
+  async create(
+    @Param('courseId', ParseIntPipe) courseId: number,
+    @Body() createRuleDto: CreateRuleDto
+  ): Promise<Rule> {
+    this.logger.log(`Creating new rule for course ${courseId}`)
+    return this.rulesService.create(courseId, createRuleDto)
   }
 
   @Put(':id')
   async update(
+    @Param('courseId', ParseIntPipe) courseId: number,
     @Param('id', ParseIntPipe) id: number,
     @Body() updateRuleDto: UpdateRuleDto
   ): Promise<Rule> {
-    this.logger.log(`Updating rule ${id}`)
-    const updatedRule = await this.rulesService.update(id, updateRuleDto)
+    this.logger.log(`Updating rule ${id} for course ${courseId}`)
+    const updatedRule = await this.rulesService.update(courseId, id, updateRuleDto)
     if (!updatedRule) {
-      throw new NotFoundException(`Rule with ID "${id}" not found`)
+      throw new NotFoundException(`Rule with ID "${id}" not found in course "${courseId}"`)
     }
     return updatedRule
   }
 
   @Delete(':id')
-  async remove(@Param('id', ParseIntPipe) id: number): Promise<void> {
-    this.logger.log(`Removing rule ${id}`)
-    await this.rulesService.remove(id)
+  async remove(
+    @Param('courseId', ParseIntPipe) courseId: number,
+    @Param('id', ParseIntPipe) id: number
+  ): Promise<void> {
+    this.logger.log(`Removing rule ${id} from course ${courseId}`)
+    await this.rulesService.remove(courseId, id)
   }
 }

--- a/backend/src/rules/rules.module.ts
+++ b/backend/src/rules/rules.module.ts
@@ -1,4 +1,4 @@
-import { Module, forwardRef } from '@nestjs/common'
+import { Module } from '@nestjs/common'
 import { TypeOrmModule } from '@nestjs/typeorm'
 import { Rule } from './entities/rule.entity'
 import { Requirement } from '../requirements/entities/requirement.entity'
@@ -7,10 +7,7 @@ import { RulesController } from './rules.controller'
 import { CoursesModule } from '../courses/courses.module'
 
 @Module({
-  imports: [
-    TypeOrmModule.forFeature([Rule, Requirement]),
-    forwardRef(() => CoursesModule), // 使用 forwardRef 来处理循环依赖
-  ],
+  imports: [TypeOrmModule.forFeature([Rule, Requirement]), CoursesModule],
   providers: [RulesService],
   controllers: [RulesController],
   exports: [TypeOrmModule, RulesService],


### PR DESCRIPTION
Allows updating multiple requirements in a single request, improving
efficiency and user experience. The `updateRequirements` method now
accepts an array of `UpdateRequirementDto`, which allows for updating
multiple requirements with a single call. The `updateRequirement`
method has been removed as it is no longer needed.